### PR TITLE
Prepend ISO date to log lines. Fixes #2.

### DIFF
--- a/deploy_dev.js
+++ b/deploy_dev.js
@@ -60,7 +60,7 @@ DevDeployer.prototype.create = function(cb) {
     self.ipAddress = /\"ipAddress\":\s\"([0-9\.]+)\"/.exec(so)[1];
 
     key.addKeysFromDirectory(self.ipAddress, process.env['PUBKEY_DIR'], function(msg) {
-      self.emit('progress', msg);
+      self.emit(new Date().toISOString() + ': progress', msg);
     }, cb);
   });
   cp.stdout.pipe(process.stdout);

--- a/deploy_server.js
+++ b/deploy_server.js
@@ -81,7 +81,7 @@ Deployer.prototype._deployNewCode = function(cb) {
     if (typeof chunk === 'string') {
       chunk.split('\n').forEach(function (line) {
         line = line.trim();
-        if (line.length) self.emit('progress', line);
+        if (line.length) self.emit(new Date().toISOString() + ': progress', line);
       });
     }
   }
@@ -110,7 +110,7 @@ Deployer.prototype._deployNewCode = function(cb) {
 Deployer.prototype._pullLatest = function(cb) {
   var self = this;
   git.pull(this._codeDir, 'git://github.com/mozilla/browserid', 'dev', function(l) {
-    self.emit('progress', l);
+    self.emit(new Date().toISOString() + ': progress', l);
   }, function(err) {
     if (err) return cb(err);
     git.currentSHA(self._codeDir, function(err, latest) {


### PR DESCRIPTION
@rfk mind having a look? This pull request prepends the ISO date to loglines, so that deployer's logs are less insane to try to read in a pinch.

I couldn't quite figure out how to test this locally, but the code looks ok to me. Thoughts?

After the Zerigo outage ends, I can push the changes onboard deployer and verify nothing's borked.
