### PR TITLE
Monkeypatch console.log to force timestamps into all log calls. Fixes #2 again.

### DIFF
--- a/deploy_server.js
+++ b/deploy_server.js
@@ -17,6 +17,10 @@ spawn = require('child_process').spawn;
 
 const DEPLOY_HOSTNAME = "login.dev.anosrep.org";
 
+// overwrite console.log with a time-aware logger
+console._log = console.log;
+console.log = function(x) { console._log(new Date().toISOString() + ": " + x) }
+
 console.log("deploy server starting up");
 
 // a class capable of deploying and emmitting events along the way


### PR DESCRIPTION
@seanmonstar thoughts? Is this dirty/lazy or brilliant? Does what it should, logs onboard deployer go from

``` bash
deploy server starting up
code dir is: /home/app/browserid_repo
deployment log dir is: /home/app/deploy_logs
ready
info: checking for updates
deploy server bound
progress: Already up-to-date.
info: latest available sha is f5218dc
resolved login.dev.anosrep.org -> 54.242.215.50
info: current running sha is: f5218dc
info: up to date
warn: Forever detected script exited with code: null
```

to

``` bash
2013-07-01T22:43:50.896Z: deploy server starting up
2013-07-01T22:43:50.898Z: code dir is:
2013-07-01T22:43:50.907Z: deployment log dir is:
2013-07-01T22:43:50.917Z: ready
2013-07-01T22:43:50.918Z: info: checking for updates
2013-07-01T22:43:50.934Z: deploy server bound
2013-07-01T22:43:51.182Z: progress: Already up-to-date.
2013-07-01T22:43:51.195Z: info: latest available sha is f5218dc
2013-07-01T22:43:51.276Z: resolved login.dev.anosrep.org -> 54.242.215.50
2013-07-01T22:43:51.284Z: info: current running sha is: f5218dc
2013-07-01T22:43:51.284Z: info: up to date
```
