### PR TITLE
updates for working with new awsbox & route53

### DIFF
--- a/lib/latest_sha.js
+++ b/lib/latest_sha.js
@@ -1,46 +1,59 @@
 var nativeDns = require('native-dns'),
          util = require('util'),
           dns = require('dns'),
-         http = require('http'); 
+         http = require('http'), 
+  NiceRoute53 = require('nice-route53');
+
+var route53 = new NiceRoute53({
+  accessKeyId : process.env['AWS_ID'],
+  secretAccessKey : process.env['AWS_SECRET'],
+});
 
 function resolve(hostname, cb) {
-  // resolve zerigo's nameserver
-  dns.resolve4('A.NS.ZERIGO.NET', function(err, ip) {
-    var question = nativeDns.Question({
-      name: hostname,
-      type: 'A',
-    });
+  // find an NS for this hostname
+  var domain = hostname.split('.').slice(1).join('.');
+  route53.zoneInfo(domain, function(err, zoneInfo) {
+    if (err) return cb(err);
+    var nameserver = zoneInfo.nameServers[0];
 
-    var req = nativeDns.Request({
-      question: question,
-      server: { address: ip[0], port: 53, type: 'udp' },
-      timeout: 4000,
-    });
-
-    req.on('timeout', function () {
-      cb('Timeout resolving ' + hostname);
-    });
-
-    var foundAddr = null;
-
-    req.on('message', function (err, answer) {
-      answer.answer.forEach(function (a) {
-        if (foundAddr) return;
-        foundAddr = a.promote().address;
+    dns.resolve4(nameserver, function(err, ip) {
+      var question = nativeDns.Question({
+        name: hostname,
+        type: 'A',
       });
-    });
 
-    req.on('end', function () {
-      cb(null, foundAddr);
+      var req = nativeDns.Request({
+        question: question,
+        server: { address: ip[0], port: 53, type: 'udp' },
+        timeout: 4000,
+      });
+
+      req.on('timeout', function () {
+        cb('Timeout resolving ' + hostname);
+      });
+
+      var foundAddr = null;
+
+      req.on('message', function (err, answer) {
+        answer.answer.forEach(function (a) {
+          if (foundAddr) return;
+          foundAddr = a.address;
+        });
+      });
+
+      req.on('end', function () {
+        cb(null, foundAddr);
+      });
+
+      req.send();
     });
-    
-    req.send();
   });
 }
 
 module.exports = function(hostname, cb) {
   resolve(hostname, function(err, ip) {
     if (err) return cb(err);
+    if (!ip) return cb('Found no IP for host ' + hostname);
     console.log(new Date().toISOString() + ': resolved ' + hostname + ' -> ' + ip);
     http.get({ host: ip, path: '/ver.txt' }, function(res) {
       var buf = "";

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "persona_deployer",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "dependencies": {
-    "awsbox": "0.3.4",
+    "awsbox": "0.5.1",
     "express": "2.5.0",
     "JSONSelect": "0.4.0",
     "irc": "0.3.3",
-    "native-dns": "0.0.7"
+    "nice-route53": "0.3.3",
+    "native-dns": "0.4.1",
+    "temp": "0.6.0"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
Some of this is overkill, but some is needed for route53. Review changes to to latest_sha.js with https://github.com/mozilla/browserid_deployer/compare/upgrade_awsbox_for_route53?w=1

Also see https://github.com/mozilla/awsbox/pull/99, which oddly is needed to pick up nice-route53@0.3.3
- made the deploy hostname, repo, branch and some others configurable via
  environment (so I could test changes without changing
  deployer.personatest.org).
- probably went too far on making this configurable ;-)
- initialize aws.createClients so vm.{list,destroy} work correctly
- improved some error messages to help log debugging
- changed lib/latest_sha.js to lookup NS (instead of hard-coded zerigo NS)
- upgraded native-dns to current to pick up a bug fix for running on osx
- added missing dep `temp@0.6.0`, and new dep nice-route53@0.3.3
- bumped the version to 0.0.2 fwiw
